### PR TITLE
Enforce consistent HTML element creation

### DIFF
--- a/htbuilder/__init__.py
+++ b/htbuilder/__init__.py
@@ -104,31 +104,26 @@ class HtmlTag(object):
         """HTML element builder."""
         self._tag = tag
 
-    def __call__(self, *args, **kwargs):
-        el = HtmlElement(self._tag)
-        el(*args, **kwargs)
-        return el
+    def __call__(self, **attrs):
+        return HtmlElement(self._tag, attrs=attrs)
 
 
 VOIDED_CHILDREN = (None, False, True)
 
 
 class HtmlElement(object):
-    def __init__(self, tag, attrs={}, children=[]):
+    def __init__(self, tag, attrs={}):
         """An HTML element."""
         self._tag = tag.lower()
         self._attrs = attrs
-        self._children = children
+        self._children = []
         self._is_empty = tag in EMPTY_ELEMENTS
 
-    def __call__(self, *children, **attrs):
+    def __call__(self, *children):
         if children:
             if self._is_empty:
                 raise TypeError("<%s> cannot have children" % self._tag)
             self._children = list(collapse([*self._children, *children]))
-
-        if attrs:
-            self._attrs = {**self._attrs, **attrs}
 
         return self
 

--- a/htbuilder/utils.py
+++ b/htbuilder/utils.py
@@ -80,8 +80,6 @@ def styles(**rules):
         for (k, v) in rules.items()
     )
 
-    return _parse_style_value(v)
-
 
 def _parse_style_value(style):
     if isinstance(style, tuple):

--- a/tests/htbuild_test.py
+++ b/tests/htbuild_test.py
@@ -173,13 +173,13 @@ class TestHtBuilder(unittest.TestCase):
             <div style="foo:10px 9px 8px"></div>
         '''))
 
-    def test_funcs_and_units_in_builder(self):
+    def test_funcs_and_units_in_builder_margin(self):
         dom = div(style=styles(margin=px(0, 0, 10, 0)))
         self.assertEqual(str(dom), normalize_whitespace('''
             <div style="margin:0 0 10px 0"></div>
         '''))
 
-    def test_funcs_and_units_in_builder(self):
+    def test_funcs_and_units_in_builder_animate(self):
         dom = div(style=styles(animate=['color', 'margin']))
         self.assertEqual(str(dom), normalize_whitespace('''
             <div style="animate:color,margin"></div>

--- a/tests/htbuild_test.py
+++ b/tests/htbuild_test.py
@@ -31,7 +31,7 @@ class TestHtBuilder(unittest.TestCase):
         )
 
     def test_basic_usage(self):
-        dom = div('hello')
+        dom = div()('hello')
         self.assertEqual(
             str(dom),
             normalize_whitespace('<div>hello</div>'),
@@ -56,7 +56,7 @@ class TestHtBuilder(unittest.TestCase):
         dom = div(id='container')(children)
         self.assertEqual(str(dom), '<div id="container">01234</div>')
 
-        dom = div(children)
+        dom = div()(children)
         self.assertEqual(str(dom), '<div>01234</div>')
 
     def test_vararg_children(self):
@@ -64,7 +64,7 @@ class TestHtBuilder(unittest.TestCase):
         dom = div(id='container')(*children)
         self.assertEqual(str(dom), '<div id="container">01234</div>')
 
-        dom = div(*children)
+        dom = div()(*children)
         self.assertEqual(str(dom), '<div>01234</div>')
 
     def test_list_children(self):
@@ -72,7 +72,7 @@ class TestHtBuilder(unittest.TestCase):
         dom = div(id='container')(children)
         self.assertEqual(str(dom), '<div id="container">01234</div>')
 
-        dom = div(children)
+        dom = div()(children)
         self.assertEqual(str(dom), '<div>01234</div>')
 
     def test_iterable_children(self):
@@ -80,7 +80,7 @@ class TestHtBuilder(unittest.TestCase):
         dom = div(id='container')(children)
         self.assertEqual(str(dom), '<div id="container">01234</div>')
 
-        dom = div(children)
+        dom = div()(children)
         self.assertEqual(str(dom), '<div>01234</div>')
 
     def test_nested_children(self):
@@ -88,17 +88,17 @@ class TestHtBuilder(unittest.TestCase):
         dom = div(id='container')(children)
         self.assertEqual(str(dom), '<div id="container">01012</div>')
 
-        dom = div(children)
+        dom = div()(children)
         self.assertEqual(str(dom), '<div>01012</div>')
 
     def test_complex_tree(self):
         dom = (
             div(id='container')(
-                h1('Examples'),
-                ul(
-                    li("Example 1"),
-                    li("Example 2"),
-                    li("Example 3"),
+                h1()('Examples'),
+                ul()(
+                    li()("Example 1"),
+                    li()("Example 2"),
+                    li()("Example 3"),
                 )
             )
         )
@@ -136,12 +136,12 @@ class TestHtBuilder(unittest.TestCase):
         )
 
     def test_functional_component(self):
-        component = ul(class_='myul')(
-            li('Hello'),
+        component = ul(class_='myul', style='color: red')(
+            li()('Hello'),
         )
 
-        dom = component(style='color: red')(
-            li('Goodbye'),
+        dom = component()(
+            li()('Goodbye'),
         )
 
         self.assertEqual(
@@ -193,8 +193,8 @@ class TestHtBuilder(unittest.TestCase):
 
     def test_fragment_tag(self):
         dom = fragment(
-            h1('hello'),
-            div('world')
+            h1()('hello'),
+            div()('world')
         )
         self.assertEqual(str(dom), normalize_whitespace('''
             <h1>hello</h1><div>world</div>
@@ -288,13 +288,13 @@ class TestHtBuilder(unittest.TestCase):
         )
 
     def test_arg_order(self):
-        dom = div("hello", foo="bar")
+        dom = div(foo="bar")("hello")
         self.assertEqual(str(dom), normalize_whitespace('''
             <div foo="bar">hello</div>
         '''))
 
     def test_repeat(self):
-        dom = div("hello", foo="bar")
+        dom = div(foo="bar")("hello")
         self.assertEqual(str(dom), normalize_whitespace('''
             <div foo="bar">hello</div>
         '''))
@@ -303,11 +303,11 @@ class TestHtBuilder(unittest.TestCase):
         '''))
 
     def test_voided_children_are_not_rendered(self):
-        dom = div("hello", None, " ", False, "world", True, "!")
+        dom = div()("hello", None, " ", False, "world", True, "!")
         self.assertEqual(str(dom), "<div>hello world!</div>")
 
     def test_unrendered_children_with_fragment(self):
-        dom = div(fragment("hello", None, " ", False, "world", True, "!"))
+        dom = div()(fragment("hello", None, " ", False, "world", True, "!"))
         self.assertEqual(str(dom), "<div>hello world!</div>")
 
 


### PR DESCRIPTION
The upstream library supports defining element attributes and children at _instantiation_ and _call_ time. This additional flexibility puts the burden on the caller to know how to build the element at call time and can also lead to attributes being buried far down in the element definition. This has lead to surprising decisions on when and where to place the attributes and children. So it was decided that we would constrain how the HTML elements are created by simply only supporting one way to do it:

```python
import htbuilder as HTB

# valid
HTB.div(class_="my-header")("Hello, world!")
HTB.h1()("Foo header")

# invalid (legacy)
HTB.div("Hello, world!", class_="my-header")
HTB.h1("Foo header")
```

You can find more examples in the changed tests. I believe the main downside of this changeset is portrayed in the second example above where there are no attributes passed to `HTB.h1`. The legacy call is more concise and natural, but I think this is an acceptable trade-off for more consistent code across the app.