### PR TITLE
Do not mix args and kwargs on html element creation

### DIFF
--- a/htbuilder/__init__.py
+++ b/htbuilder/__init__.py
@@ -105,9 +105,11 @@ class HtmlTag(object):
         self._tag = tag
 
     def __call__(self, *args, **kwargs):
-        el = HtmlElement(self._tag)
-        el(*args, **kwargs)
-        return el
+        if args and kwargs:
+            raise ValueError("Accept args or kwargs in element, but not both.")
+
+        return HtmlElement(self._tag)(*args, **kwargs)
+
 
 
 VOIDED_CHILDREN = (None, False, True)

--- a/tests/htbuild_test.py
+++ b/tests/htbuild_test.py
@@ -287,14 +287,11 @@ class TestHtBuilder(unittest.TestCase):
             normalize_whitespace("""<div foo bar="baz"></div>"""),
         )
 
-    def test_arg_order(self):
-        dom = div("hello", foo="bar")
-        self.assertEqual(str(dom), normalize_whitespace('''
-            <div foo="bar">hello</div>
-        '''))
+    def test_both_children_and_attrs_raises(self):
+        self.assertRaises(ValueError, lambda: div("hello", foo="bar"))
 
     def test_repeat(self):
-        dom = div("hello", foo="bar")
+        dom = div(foo="bar")("hello")
         self.assertEqual(str(dom), normalize_whitespace('''
             <div foo="bar">hello</div>
         '''))


### PR DESCRIPTION
An improved solution based on #3 

Instead of forcing the caller to pass attributes on `__init__` and children on `__call__`, we accept both styles, but _do not_ allow the mixing of `args` and `kwargs`.

```python
import htbuilder as HTB

# valid
HTB.div(class_="foo")("Hello, World!")
HTB.div("Hello, World!")

# invalid
HTB.div("Hello, World!", class_="foo")
```
This solution accomplishes our goal of not allowing `kwargs`  to be buried at the end of the function call, while maintaining the simple API when said `kwargs` are not required.